### PR TITLE
Remove comments and clean up TinyDX_V1.4.ino

### DIFF
--- a/TinyDX FIRMWARE/TinyDX_V1.4.ino
+++ b/TinyDX FIRMWARE/TinyDX_V1.4.ino
@@ -308,43 +308,24 @@ if (freqdiv > 25 && freqdiv < 30){
 //********************************************************************************
 
 void Band_Select(){
-M = digitalRead(M_SW);
-B = digitalRead(B_SW);
+  M = digitalRead(M_SW);
+  B = digitalRead(B_SW);
 
-if ((B == LOW)&&(M == LOW)) {
-   delay(100); 
-if ((B == LOW)&&(M == LOW)) 
- {
- freq = B1_FT8;   
+  if ((B == LOW)&&(M == LOW)) {
+    freq = B1_FT8;   
   }
-}
 
-
-if ((B == LOW)&&(M == HIGH)) {
-   delay(100); 
-if ((B == LOW)&&(M == HIGH)) 
- {
- freq = B1_FT4;   
+  if ((B == LOW)&&(M == HIGH)) {
+    freq = B1_FT4;   
   }
-}
 
-
-if ((B == HIGH)&&(M == LOW)) {
-   delay(100); 
-if ((B == HIGH)&&(M == LOW)) 
- {
- freq = B2_FT8;   
+  if ((B == HIGH)&&(M == LOW)) {
+    freq = B2_FT8;   
   }
-}
 
-
-if ((B == HIGH)&&(M == HIGH)) {
-   delay(100); 
-if ((B == HIGH)&&(M == HIGH)) 
- {
- freq = B2_FT4;   
+  if ((B == HIGH)&&(M == HIGH)) {
+   freq = B2_FT4;   
   }
-}
 }
 
 
@@ -392,3 +373,4 @@ void Freq_assign() {
   }
 }
 //************************[ End of Frequency assign function ]*************************
+


### PR DESCRIPTION
Hi Barb,

This is the thing I mentioned in my other Pullrequest may be a bug.

In fact the Band_Select() function is executed in every execution of the loop-function.
In the BAND select function there are two things I recognized.
- There are four possible path. In each path, there is a delay of 100ms, this means the Function will delay each loop by 100ms. This may cause delays in the FSK output during transmit times.

- There is a reading of the switches which is stored into variables. Than the path is evaluated. In each path the evaluation is done again. This must not be done, because its checking the variables and not the inputvalues, so the variables cant change between those lines.

Imho the second check is obsolete. 
If you think the delay is still needed, I would place the delay outside of the if statements. This will make the code more readable and also result in smaller code, because its just one call to delay instead of four.

73 de DC4DIY aka Christian